### PR TITLE
Add Initial GitHub Action matching Candidco's usage [sc-93115]

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering a respectful and welcoming environment, we as contributors and maintainers pledge to make participation in our project and community a positive experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Using respectful language
+- Being considerate of differing viewpoints and experiences
+- Accepting constructive criticism gracefully
+- Focusing on what is best for the community
+- Showing understanding towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of inappropriate language or imagery and unwelcome attention or advances
+- Trolling, insulting/derogatory comments, and personal attacks
+- Public or private harassment
+- Publishing others’ private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior will be reviewed and investigated, and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.4.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to headscale-connect-action
+
+Thank you for considering contributing to this project! We welcome contributions from everyone. By participating in this project, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## How to Contribute
+
+### Reporting Bugs
+
+- Ensure the bug was not already reported by searching on GitHub under [Issues](https://github.com/candidco/headscale-connect-action/issues).
+- If you're unable to find an open issue addressing the problem, open a new one. Be sure to include a title and clear description, as much relevant information as possible, and a code sample or an executable test case demonstrating the expected behavior that is not occurring.
+
+### Suggesting Enhancements
+
+- Search the existing [Issues](https://github.com/candidco/headscale-connect-action/issues) and [Pull Requests](https://github.com/candidco/headscale-connect-action/pulls) to ensure that your idea hasn't been addressed yet.
+- If you find a related issue, feel free to add your thoughts and ideas.
+- If your enhancement suggestion is new, please open an issue and describe the enhancement you would like to see, why you think it would be beneficial, and any other relevant information.
+
+### Pull Requests
+
+- Fork the repository and create your branch from `master`.
+- If you've added code that should be tested, add tests.
+- Ensure the test suite passes.
+- Make sure your code lints.
+- Issue that pull request!
+
+### Code Style
+
+- Follow the existing code style and conventions.
+- Write clear, concise commit messages.
+
+## Additional Resources
+
+- [General GitHub Documentation](https://docs.github.com/)
+- [GitHub Pull Request Documentation](https://docs.github.com/en/pull-requests)
+- [GitHub Issues Documentation](https://docs.github.com/en/issues)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
-# headscale-connect-action
-GitHub Action to connect to a Headscale server using Tailscale CLI
+## About
+
+GitHub Action to connect a runner to a Headscale server using the Tailscale CLI. This action installs and configures the necessary tools to establish a secure connection to a Headscale server.
+
+## Usage
+
+### Quick start
+
+```yaml
+name: Connect to Headscale
+
+on:
+  push:
+
+jobs:
+  connect:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Connect to Headscale
+        uses: candidco/headscale-connect-action@v1
+        with:
+          headscale-cli-address: 'your-headscale-server-address'
+          headscale-cli-api-key: 'your-api-key'
+```
+
+## Customizing
+
+### inputs
+
+The following inputs can be used as `step.with` keys:
+
+| Name                           | Type   | Default             | Description                                                                                   |
+|--------------------------------|--------|---------------------|-----------------------------------------------------------------------------------------------|
+| `headscale-cli-address`        | String |                     | The address of the Headscale CLI.                                                             |
+| `headscale-cli-api-key`        | String |                     | The API key for the Headscale CLI.                                                            |
+| `headscale-user`               | String | `github-actions`    | The user to create or use in Headscale.                                                       |
+| `headscale-preauthkey-expiration` | String | `30m`               | The expiration time for the preauth key.                                                      |
+| `headscale-version`            | String | `0.25.1`            | The version of Headscale to install.                                                          |
+| `headscale-os-arch`            | String | `linux_amd64`       | The OS and architecture for the Headscale binary.                                             |
+
+## Outputs
+
+This action does not produce any outputs.
+
+## Contributing
+
+Want to contribute? Awesome! Contributions are welcome. Please check the [CONTRIBUTING.md](/.github/CONTRIBUTING.md) for guidelines.
+
+## License
+
+This project is licensed under the Apache-2.0 License. See the [LICENSE](LICENSE) file for more details.

--- a/action.yml
+++ b/action.yml
@@ -2,16 +2,6 @@ name: "Connect to Headscale"
 description: "Connects to a Headscale using the Tailscale CLI"
 
 inputs:
-  aws-access-key-id:
-    description: "AWS Access Key ID"
-    required: true
-  aws-secret-access-key:
-    description: "AWS Secret Access Key"
-    required: true
-  aws-region:
-    description: "AWS Region"
-    required: false
-    default: "us-east-1"
   headscale-cli-address:
     description: "Headscale CLI Address"
     required: true
@@ -26,13 +16,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-
-    - id: configure-aws-credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
-        aws-region: ${{ inputs.aws-region }}
 
     - id: install-headscale-cli
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -65,17 +65,19 @@ runs:
         echo "TAILSCALE_CLI_AUTH_KEY=$TAILSCALE_CLI_AUTH_KEY" >> $GITHUB_ENV
 
     - id: connect-tailscale
-      shell: bash
-      env:
-        HEADSCALE_CLI_ADDRESS: ${{ inputs.headscale-cli-address }}
-      run: |
-        echo "Connecting to Tailscale..."
-        sudo tailscale up \
-          --accept-dns \
-          --accept-routes \
-          --authkey=${TAILSCALE_CLI_AUTH_KEY} \
-          --login-server=https://${HEADSCALE_CLI_ADDRESS} \
-          --operator=${USER} \
-          --timeout=90s 
-        echo "Tailscale status:"
-        tailscale status
+      uses: gacts/run-and-post-run@v1.4.2
+      with:
+        run: |
+          echo "Connecting to Tailscale..."
+          sudo tailscale up \
+            --accept-dns \
+            --accept-routes \
+            --authkey=${TAILSCALE_CLI_AUTH_KEY} \
+            --login-server=https://${{ inputs.headscale-cli-address }} \
+            --operator=${USER} \
+            --timeout=90s 
+          echo "Tailscale status:"
+          tailscale status
+        post: |
+          tailscale down || true
+          echo "Tailscale is down!"

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Connect to Headscale"
-description: "Connects to a Headscale using the Tailscale CLI"
+description: "Connects to a Headscale server using the Tailscale CLI"
 
 inputs:
   headscale-cli-address:
@@ -12,6 +12,18 @@ inputs:
     description: "Headscale User"
     required: false
     default: "github-actions"
+  headscale-preauthkey-expiration:
+    description: "Headscale Preauthkey Expiration"
+    required: false
+    default: "30m"
+  headscale-version:
+    description: "Headscale Version"
+    required: false
+    default: "0.25.1"
+  headscale-os-arch:
+    description: "Headscale OS and Architecture (see https://github.com/juanfont/headscale/releases for options)"
+    required: false
+    default: "linux_amd64"
 
 runs:
   using: "composite"
@@ -19,11 +31,14 @@ runs:
 
     - id: install-headscale-cli
       shell: bash
+      env:
+        HEADSCALE_VERSION: ${{ inputs.headscale-version }}
+        HEADSCALE_OS_ARCH: ${{ inputs.headscale-os-arch }}
       run: |
         set -e
         echo "Installing and configuring headscale cli"
         mkdir -p $HOME/.local/bin
-        curl -L -s -o $HOME/.local/bin/headscale https://github.com/juanfont/headscale/releases/download/v0.25.1/headscale_0.25.1_linux_amd64
+        curl -L -s -o $HOME/.local/bin/headscale https://github.com/juanfont/headscale/releases/download/v${HEADSCALE_VERSION}/headscale_${HEADSCALE_VERSION}_${HEADSCALE_OS_ARCH}
         chmod +x $HOME/.local/bin/headscale
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         
@@ -43,13 +58,14 @@ runs:
         HEADSCALE_CLI_ADDRESS: ${{ inputs.headscale-cli-address }}
         HEADSCALE_CLI_API_KEY: ${{ inputs.headscale-cli-api-key }}
         HEADSCALE_USER: ${{ inputs.headscale-user }}
+        HEADSCALE_PREAUTHKEY_EXPIRATION: ${{ inputs.headscale-preauthkey-expiration }}
       run: |
         set -e
         echo "Creating user $HEADSCALE_USER..."
         headscale -c $HOME/.headscale/config.yaml user create $HEADSCALE_USER || true
 
         echo "Creating preauthkey for user $HEADSCALE_USER..."
-        TAILSCALE_CLI_AUTH_KEY=$(headscale -c $HOME/.headscale/config.yaml preauthkey create --ephemeral --user $HEADSCALE_USER --expiration 30m -o json | jq -r .key)
+        TAILSCALE_CLI_AUTH_KEY=$(headscale -c $HOME/.headscale/config.yaml preauthkey create --ephemeral --user $HEADSCALE_USER --expiration $HEADSCALE_PREAUTHKEY_EXPIRATION -o json | jq -r .key)
         echo "TAILSCALE_CLI_AUTH_KEY=$TAILSCALE_CLI_AUTH_KEY" >> $GITHUB_ENV
 
     - id: connect-tailscale

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,8 @@ runs:
 
         echo "Creating preauthkey for user $HEADSCALE_USER..."
         TAILSCALE_CLI_AUTH_KEY=$(headscale -c $HOME/.headscale/config.yaml preauthkey create --ephemeral --user $HEADSCALE_USER --expiration $HEADSCALE_PREAUTHKEY_EXPIRATION -o json | jq -r .key)
+        # Mask the auth key in the logs
+        echo "::add-mask::$TAILSCALE_CLI_AUTH_KEY"
         echo "TAILSCALE_CLI_AUTH_KEY=$TAILSCALE_CLI_AUTH_KEY" >> $GITHUB_ENV
 
     - id: connect-tailscale

--- a/action.yml
+++ b/action.yml
@@ -80,4 +80,5 @@ runs:
           --login-server=https://${HEADSCALE_CLI_ADDRESS} \
           --operator=${USER} \
           --timeout=90s 
+        echo "Tailscale status:"
         tailscale status

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,6 @@ runs:
         HEADSCALE_VERSION: ${{ inputs.headscale-version }}
         HEADSCALE_OS_ARCH: ${{ inputs.headscale-os-arch }}
       run: |
-        set -e
         echo "Installing and configuring headscale cli"
         mkdir -p $HOME/.local/bin
         curl -L -s -o $HOME/.local/bin/headscale https://github.com/juanfont/headscale/releases/download/v${HEADSCALE_VERSION}/headscale_${HEADSCALE_VERSION}_${HEADSCALE_OS_ARCH}
@@ -46,7 +45,6 @@ runs:
     - id: install-tailscale-cli
       shell: bash
       run: |
-        set -x
         echo "Installing Tailscale cli"
         curl -fsSL https://tailscale.com/install.sh | sh
 
@@ -58,7 +56,6 @@ runs:
         HEADSCALE_USER: ${{ inputs.headscale-user }}
         HEADSCALE_PREAUTHKEY_EXPIRATION: ${{ inputs.headscale-preauthkey-expiration }}
       run: |
-        set -e
         echo "Creating user $HEADSCALE_USER..."
         headscale -c $HOME/.headscale/config.yaml user create $HEADSCALE_USER || true
         echo "Creating preauthkey for user $HEADSCALE_USER..."

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-
     - id: install-headscale-cli
       shell: bash
       env:
@@ -41,7 +40,6 @@ runs:
         curl -L -s -o $HOME/.local/bin/headscale https://github.com/juanfont/headscale/releases/download/v${HEADSCALE_VERSION}/headscale_${HEADSCALE_VERSION}_${HEADSCALE_OS_ARCH}
         chmod +x $HOME/.local/bin/headscale
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        
         # Create an empty config file (workaround for issue https://github.com/juanfont/headscale/issues/2193)
         mkdir -p $HOME/.headscale && touch $HOME/.headscale/config.yaml
     
@@ -63,7 +61,6 @@ runs:
         set -e
         echo "Creating user $HEADSCALE_USER..."
         headscale -c $HOME/.headscale/config.yaml user create $HEADSCALE_USER || true
-
         echo "Creating preauthkey for user $HEADSCALE_USER..."
         TAILSCALE_CLI_AUTH_KEY=$(headscale -c $HOME/.headscale/config.yaml preauthkey create --ephemeral --user $HEADSCALE_USER --expiration $HEADSCALE_PREAUTHKEY_EXPIRATION -o json | jq -r .key)
         # Mask the auth key in the logs

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,85 @@
+name: "Connect to Headscale"
+description: "Connects to a Headscale using the Tailscale CLI"
+
+inputs:
+  aws-access-key-id:
+    description: "AWS Access Key ID"
+    required: true
+  aws-secret-access-key:
+    description: "AWS Secret Access Key"
+    required: true
+  aws-region:
+    description: "AWS Region"
+    required: false
+    default: "us-east-1"
+  headscale-cli-address:
+    description: "Headscale CLI Address"
+    required: true
+  headscale-cli-api-key:
+    description: "Headscale CLI API Key"
+    required: true
+  headscale-user:
+    description: "Headscale User"
+    required: false
+    default: "github-actions"
+
+runs:
+  using: "composite"
+  steps:
+
+    - id: configure-aws-credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - id: install-headscale-cli
+      shell: bash
+      run: |
+        set -e
+        echo "Installing and configuring headscale cli"
+        mkdir -p $HOME/.local/bin
+        curl -L -s -o $HOME/.local/bin/headscale https://github.com/juanfont/headscale/releases/download/v0.23.0/headscale_0.23.0_linux_amd64
+        chmod +x $HOME/.local/bin/headscale
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        
+        # Create an empty config file (workaround for issue https://github.com/juanfont/headscale/issues/2193)
+        mkdir -p $HOME/.headscale && touch $HOME/.headscale/config.yaml
+    
+    - id: install-tailscale-cli
+      shell: bash
+      run: |
+        set -x
+        echo "Installing Tailscale cli"
+        curl -fsSL https://tailscale.com/install.sh | sh
+
+    - id: configure-headscale-user
+      shell: bash
+      env:
+        HEADSCALE_CLI_ADDRESS: ${{ inputs.headscale-cli-address }}
+        HEADSCALE_CLI_API_KEY: ${{ inputs.headscale-cli-api-key }}
+        HEADSCALE_USER: ${{ inputs.headscale-user }}
+      run: |
+        set -e
+        echo "Creating user $HEADSCALE_USER..."
+        headscale -c $HOME/.headscale/config.yaml user create $HEADSCALE_USER || true
+
+        echo "Creating preauthkey for user $HEADSCALE_USER..."
+        TAILSCALE_CLI_AUTH_KEY=$(headscale -c $HOME/.headscale/config.yaml preauthkey create --ephemeral --user $HEADSCALE_USER --expiration 30m -o json | jq -r .key)
+        echo "TAILSCALE_CLI_AUTH_KEY=$TAILSCALE_CLI_AUTH_KEY" >> $GITHUB_ENV
+
+    - id: connect-tailscale
+      shell: bash
+      env:
+        HEADSCALE_CLI_ADDRESS: ${{ inputs.headscale-cli-address }}
+      run: |
+        echo "Connecting to Tailscale..."
+        sudo tailscale up \
+          --accept-dns \
+          --accept-routes \
+          --authkey=${TAILSCALE_CLI_AUTH_KEY} \
+          --login-server=https://${HEADSCALE_CLI_ADDRESS} \
+          --operator=${USER} \
+          --timeout=90s 
+        tailscale status

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
         set -e
         echo "Installing and configuring headscale cli"
         mkdir -p $HOME/.local/bin
-        curl -L -s -o $HOME/.local/bin/headscale https://github.com/juanfont/headscale/releases/download/v0.23.0/headscale_0.23.0_linux_amd64
+        curl -L -s -o $HOME/.local/bin/headscale https://github.com/juanfont/headscale/releases/download/v0.25.1/headscale_0.25.1_linux_amd64
         chmod +x $HOME/.local/bin/headscale
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         


### PR DESCRIPTION
Adds a custom GitHub Action that connects to a Headscale server. This implementation adheres to Candid's specific usage.

Here's a snippet of how to use this action:

```yaml
name: Connect to Headscale

on:
  push:

jobs:
  connect:
    runs-on: ubuntu-latest
    steps:
      - name: Connect to Headscale
        uses: candidco/headscale-connect-action@v1
        with:
          headscale-cli-address: 'your-headscale-server-address'
          headscale-cli-api-key: 'your-api-key'
```

Here's the output of a workflow using the action on this branch:

![Screenshot 2025-04-09 at 17 44 15](https://github.com/user-attachments/assets/70df0ea8-f7f5-4c27-a6a7-71ea9645b1be)
