### PR TITLE
Support minimum headscale 0.27.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following inputs can be used as `step.with` keys:
 | `headscale-cli-api-key`        | String |                     | The API key for the Headscale CLI.                                                            |
 | `headscale-user`               | String | `github-actions`    | The user to create or use in Headscale.                                                       |
 | `headscale-preauthkey-expiration` | String | `30m`               | The expiration time for the preauth key.                                                      |
-| `headscale-version`            | String | `0.25.1`            | The version of Headscale to install.                                                          |
+| `headscale-version`            | String | `0.27.1`            | The version of Headscale to install (minimum supported: 0.27.1).                              |
 | `headscale-os-arch`            | String | `linux_amd64`       | The OS and architecture for the Headscale binary.                                             |
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,32 @@ runs:
         # Create an empty config file (workaround for issue https://github.com/juanfont/headscale/issues/2193)
         mkdir -p $HOME/.headscale && touch $HOME/.headscale/config.yaml
     
+    - id: verify-headscale-version
+      shell: bash
+      env:
+        HEADSCALE_VERSION: ${{ inputs.headscale-version }}
+      run: |
+        echo "Verifying headscale version..."
+        MIN_VERSION="0.27.1"
+        INSTALLED_VERSION=$(headscale -c $HOME/.headscale/config.yaml version -o json 2>/dev/null | jq -r '.version // empty' | sed 's/^v//' | sed 's/+.*$//' || headscale -c $HOME/.headscale/config.yaml version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+        
+        if [ -z "$INSTALLED_VERSION" ]; then
+          echo "Error: Could not determine installed headscale version"
+          exit 1
+        fi
+        
+        echo "Installed version: $INSTALLED_VERSION (minimum required: $MIN_VERSION)"
+        
+        # Compare versions using sort -V (version sort)
+        # If installed version is less than minimum, it will be sorted first
+        SORTED_FIRST=$(printf '%s\n' "$MIN_VERSION" "$INSTALLED_VERSION" | sort -V | head -1)
+        if [ "$SORTED_FIRST" = "$INSTALLED_VERSION" ] && [ "$INSTALLED_VERSION" != "$MIN_VERSION" ]; then
+          echo "::error::Headscale version $INSTALLED_VERSION is below minimum required version $MIN_VERSION"
+          exit 1
+        fi
+        
+        echo "Version check passed: $INSTALLED_VERSION >= $MIN_VERSION"
+    
     - id: install-tailscale-cli
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
   headscale-version:
     description: "Headscale Version"
     required: false
-    default: "0.25.1"
+    default: "0.27.1"
   headscale-os-arch:
     description: "Headscale OS and Architecture (see https://github.com/juanfont/headscale/releases for options)"
     required: false
@@ -61,9 +61,18 @@ runs:
         HEADSCALE_PREAUTHKEY_EXPIRATION: ${{ inputs.headscale-preauthkey-expiration }}
       run: |
         echo "Creating user $HEADSCALE_USER..."
-        headscale -c $HOME/.headscale/config.yaml user create $HEADSCALE_USER || true
-        echo "Creating preauthkey for user $HEADSCALE_USER..."
-        TAILSCALE_CLI_AUTH_KEY=$(headscale -c $HOME/.headscale/config.yaml preauthkey create --ephemeral --user $HEADSCALE_USER --expiration $HEADSCALE_PREAUTHKEY_EXPIRATION -o json | jq -r .key)
+        headscale -c $HOME/.headscale/config.yaml users create $HEADSCALE_USER || true
+        
+        # Get user ID (required for headscale 0.27.1+)
+        echo "Getting user ID for $HEADSCALE_USER..."
+        USER_ID=$(headscale -c $HOME/.headscale/config.yaml users list --name $HEADSCALE_USER -o json | jq -r '.[0].id')
+        if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+          echo "Error: Could not find user ID for $HEADSCALE_USER"
+          exit 1
+        fi
+        
+        echo "Creating preauthkey for user $HEADSCALE_USER (ID: $USER_ID)..."
+        TAILSCALE_CLI_AUTH_KEY=$(headscale -c $HOME/.headscale/config.yaml preauthkeys create --ephemeral --user $USER_ID --expiration $HEADSCALE_PREAUTHKEY_EXPIRATION -o json | jq -r .key)
         # Mask the auth key in the logs
         echo "::add-mask::$TAILSCALE_CLI_AUTH_KEY"
         echo "TAILSCALE_CLI_AUTH_KEY=$TAILSCALE_CLI_AUTH_KEY" >> $GITHUB_ENV


### PR DESCRIPTION
Updates the action to support Headscale 0.27.1 as the minimum required version.

## Changes

- Updated default version from `0.25.1` to `0.27.1`
- Added version verification step to enforce minimum version requirement
- Updated API commands to match Headscale 0.27.1+ changes:
  - `user create` → `users create`
  - `preauthkey create` → `preauthkeys create`
  - Use user ID instead of username for preauthkey creation (required in 0.27.1+)